### PR TITLE
Adds client_max_body_size configurable by ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY default.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
 COPY docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
+ENV CLIENT_MAX_BODY_SIZE 20M
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/default.conf
+++ b/default.conf
@@ -1,7 +1,7 @@
 server {
     listen       80;
     server_name  _;
-
+    client_max_body_size $CLIENT_MAX_BODY_SIZE;
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,6 @@ fi
 
 cp /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.template
 
-envsubst '$RESOLVERS $UPSTREAM_HTTP_ADDRESS' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '$RESOLVERS $UPSTREAM_HTTP_ADDRESS $CLIENT_MAX_BODY_SIZE' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 exec "$@"


### PR DESCRIPTION
Enables reverse proxy to upload larger documents by a configurable size by using env CLIENT_MAX_BODY_SIZE.
E..g. if you are running a docker registry behind this reverse proxy, you can set a larger client_max_body_size to enable pushing of larger docker image layers which otherwise would fail.