### PR TITLE
Disable ipv6 lookup on resolver

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -8,7 +8,7 @@ server {
     # 127.0.0.11 is DNS set up by Docker, see:
     # https://docs.docker.com/engine/userguide/networking/configure-dns/
     # https://github.com/moby/moby/issues/20026
-    resolver $RESOLVERS valid=10s;
+    resolver $RESOLVERS valid=10s ipv6=off;
     set $upstream $UPSTREAM_HTTP_ADDRESS;
 
     location / {


### PR DESCRIPTION
Hello.

This pull request adds a configuration to disable IPV6 lookups in the resolver.

Currently, Docker does not support IPV6, but when you reverse proxy to a host with IPV6 enabled, the following warning is output to the log.

```
[warn] 12#12: *4 upstream server temporarily disabled while connecting to upstream, client: 10.0.1.9, server: _, request: "GET /test.css HTTP/1.0", upstream: "http://[xxx::xxx]:9080/test.css", host: "example.com", referrer: "https://example.com/index.html"
```

I have added this setting to prevent this warning.
Specifically, `ipv6=off` is added to the `resolver` settings.
However, I have not tested it, so it may not work properly.
Also, if this setting is not appropriate, please feel free to close the pull request.

Sincerely.