### PR TITLE
Update default.conf to include X-Forwarded-Host overwrite as default

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -16,6 +16,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Forwarded-Proto $scheme;
         # add support for websockets
         proxy_set_header Upgrade $http_upgrade; 


### PR DESCRIPTION
This prevents X-Forwarded forgery if upstream services trust the headers set by nginx, and downstream clients can set falsified forward headers.
I see this as being a good default for a reverse proxy.