### PR TITLE
Add support for HTTPS upstream, make sure to pass the upstream Host header

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -11,9 +11,20 @@ server {
     resolver $RESOLVERS valid=10s ipv6=off;
     set $upstream $UPSTREAM_HTTP_ADDRESS;
 
+    # Extract hostname from the upstream URL to use in the Host header
+    set $upstream_host $upstream;
+    if ($upstream ~* ^https?://([^:/]+)) {
+        set $upstream_host $1;
+    }
+
+    # Add these SSL configuration settings, in case upstream is a HTTPS server
+    proxy_ssl_server_name on;
+    proxy_ssl_protocols TLSv1.2 TLSv1.3;
+    proxy_ssl_verify off;
+
     location / {
         proxy_pass $upstream;
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $upstream_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $http_host;

--- a/default.conf
+++ b/default.conf
@@ -11,16 +11,19 @@ server {
     resolver $RESOLVERS valid=10s ipv6=off;
     set $upstream $UPSTREAM_HTTP_ADDRESS;
 
-    # Extract hostname from the upstream URL to use in the Host header
-    set $upstream_host $upstream;
-    if ($upstream ~* ^https?://([^:/]+)) {
+    # Use the current host as the upstream host by default
+    set $upstream_host $http_host;
+
+    # Check if our upstream address is HTTPS
+    if ($upstream ~* ^https://([^:/]+)) {
+        # Add these SSL configuration settings
+        proxy_ssl_server_name on;
+        proxy_ssl_protocols TLSv1.2 TLSv1.3;
+        proxy_ssl_verify off;
+
+        # We also want to use the upstream host so SNI can be used - extract it from the upstream address
         set $upstream_host $1;
     }
-
-    # Add these SSL configuration settings, in case upstream is a HTTPS server
-    proxy_ssl_server_name on;
-    proxy_ssl_protocols TLSv1.2 TLSv1.3;
-    proxy_ssl_verify off;
 
     location / {
         proxy_pass $upstream;


### PR DESCRIPTION
This PR adds:
* Support for HTTPS upstream URLs, e.g. when reverse proxying a Cloudflare worker or some other site that is only accessible through HTTPS
* Pass the upstream hostname in the `Host` header - so the upstream server doesn't need to support the additional reverse proxy hostname